### PR TITLE
feat: make full build of animate.css optional

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -4,9 +4,9 @@ export default defineBuildConfig({
   entries: [
     'src/index',
   ],
-  externals:[
+  externals: [
     '@unocss/preset-mini/utils',
-    '@unocss/core'
+    '@unocss/core',
   ],
   declaration: true,
   clean: true,

--- a/docs/.vitepress/components/Animated.vue
+++ b/docs/.vitepress/components/Animated.vue
@@ -3,7 +3,8 @@
 </script>
 
 <template>
-  <div class="
+  <div
+    class="
     animated
     animated-bounce
     animated-flash

--- a/docs/.vitepress/components/Demo.vue
+++ b/docs/.vitepress/components/Demo.vue
@@ -1,100 +1,101 @@
 <script setup lang="ts">
-  import { ref } from 'vue'
-  import Animated from './Animated.vue'
-  import animations from '../utils/animations'
-  const animation = ref(Object.values(animations)[0][0].value)
-  const repeat = ref(false)
-  const shouldAnimate = ref(false)
-  const copied = ref(false)
-  const handleRepeat: EventListener = (e) => {
-    repeat.value = !repeat.value
-  }
-  const handleChange: EventListener = (e) => {
-    shouldAnimate.value = true
-    animation.value = (e.target as HTMLSelectElement).value
-  }
-  const reset: EventListener = () => {
-    shouldAnimate.value = false
-  }
-  const rerun: EventListener = () => {
-    shouldAnimate.value = true
-  }
-  const copy: EventListener = () => {
-    navigator.clipboard
-      .writeText(`animated-${animation.value}${repeat.value ? ' animated-infinite' : ''}`)
-      .then(() => {
-        copied.value = true
-      })
-    setTimeout(() => {
-      copied.value = false
-    }, 1200)
-  }
-  </script>
+import { ref } from 'vue'
+import animations from '../utils/animations'
+import Animated from './Animated.vue'
 
-  <template>
-    <div class="mt-6 flex flex-col">
-      <div
-        class="relative flex items-center justify-center overflow-hidden rounded-md bg-[#f0f0f0]  p-20 sm:p-32 dark:bg-[#202020]"
+const animation = ref(Object.values(animations)[0][0].value)
+const repeat = ref(false)
+const shouldAnimate = ref(false)
+const copied = ref(false)
+const handleRepeat: EventListener = () => {
+  repeat.value = !repeat.value
+}
+const handleChange: EventListener = (e) => {
+  shouldAnimate.value = true
+  animation.value = (e.target as HTMLSelectElement).value
+}
+const reset: EventListener = () => {
+  shouldAnimate.value = false
+}
+const rerun: EventListener = () => {
+  shouldAnimate.value = true
+}
+const copy: EventListener = () => {
+  navigator.clipboard
+    .writeText(`animated-${animation.value}${repeat.value ? ' animated-infinite' : ''}`)
+    .then(() => {
+      copied.value = true
+    })
+  setTimeout(() => {
+    copied.value = false
+  }, 1200)
+}
+</script>
+
+<template>
+  <div class="mt-6 flex flex-col">
+    <div
+      class="relative flex items-center justify-center overflow-hidden rounded-md bg-[#f0f0f0]  p-20 sm:p-32 dark:bg-[#202020]"
+    >
+      <Animated />
+      <img
+        class="w-32 animated"
+        :class="{ [`animated-${animation}`]: shouldAnimate, 'animated-infinite': repeat }"
+        src="/unocss.svg"
+        @animationend="reset"
       >
-        <Animated />
-        <img
-          class="w-32 animated"
-          :class="{ [`animated-${animation}`]: shouldAnimate, 'animated-infinite': repeat }"
-          src="/unocss.svg"
-          @animationend="reset"
-        >
-        <button
-          id="repeat"
-          class="absolute bottom-2 right-4 rounded-md border-2 border-green-600 p-2 text-black dark:text-white"
-          :class="{ 'bg-green text-white': repeat }"
-          type="button"
-          @click="handleRepeat"
-        >
-          Repeat
-        </button>
-      </div>
-      <div class="mt-6 flex self-center">
-        <button class="rounded-l-md bg-[#f0f0f0] py-1 px-4 dark:bg-[#202020]" type="button" @click="copy">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="my-[3px] h-6 w-6"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              :class="copied ? 'hidden' : 'block'"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"
-            />
-            <path
-              :class="copied ? 'block' : 'hidden'"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
-            />
-          </svg>
-        </button>
-        <select
-          aria-label="Choose an animation."
-          class="appearance-none border-x border-[#333] bg-[#f0f0f0] py-1 px-4 dark:bg-[#202020]"
-          @change="handleChange"
-        >
-          <optgroup v-for="(keyframes, type) in animations" :label="type">
-            <option v-for="keyframe in keyframes" :value="keyframe.value">
-              {{ keyframe.label }}
-            </option>
-          </optgroup>
-        </select>
-        <button type="button" class="rounded-r-md bg-[#f0f0f0] py-1 px-4 dark:bg-[#202020]" @click="rerun">
-          Animate
-        </button>
-      </div>
+      <button
+        id="repeat"
+        class="absolute bottom-2 right-4 rounded-md border-2 border-green-600 p-2 text-black dark:text-white"
+        :class="{ 'bg-green text-white': repeat }"
+        type="button"
+        @click="handleRepeat"
+      >
+        Repeat
+      </button>
     </div>
-  </template>
+    <div class="mt-6 flex self-center">
+      <button class="rounded-l-md bg-[#f0f0f0] py-1 px-4 dark:bg-[#202020]" type="button" @click="copy">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="my-[3px] h-6 w-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            :class="copied ? 'hidden' : 'block'"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"
+          />
+          <path
+            :class="copied ? 'block' : 'hidden'"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
+          />
+        </svg>
+      </button>
+      <select
+        aria-label="Choose an animation."
+        class="appearance-none border-x border-[#333] bg-[#f0f0f0] py-1 px-4 dark:bg-[#202020]"
+        @change="handleChange"
+      >
+        <optgroup v-for="(keyframes, type) in animations" :key="type" :label="type">
+          <option v-for="keyframe in keyframes" :key="keyframe.value" :value="keyframe.value">
+            {{ keyframe.label }}
+          </option>
+        </optgroup>
+      </select>
+      <button type="button" class="rounded-r-md bg-[#f0f0f0] py-1 px-4 dark:bg-[#202020]" @click="rerun">
+        Animate
+      </button>
+    </div>
+  </div>
+</template>
 
   <style scoped>
   </style>

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitepress'
-import { description, discord, font, github, name, releases, twitter,} from './meta'
-import {version} from '../../package.json'
+import { version } from '../../package.json'
+import { description, discord, font, github, name, releases, twitter } from './meta'
 
 export default defineConfig({
   lang: 'en-US',
@@ -52,52 +52,51 @@ export default defineConfig({
       },
     ],
     sidebar: {
-      '/':[
+      '/': [
         {
-          text:'Guide',
-          items:[
+          text: 'Guide',
+          items: [
             {
-              text:'Getting Started',
-              link:'/guide/'
-            }
-          ]
+              text: 'Getting Started',
+              link: '/guide/',
+            },
+          ],
         },
         {
-          text:'utilities',
-          items:[
+          text: 'utilities',
+          items: [
             {
-              text:'Animation Name',
-              link:'/utilities/animation-name'
+              text: 'Animation Name',
+              link: '/utilities/animation-name',
             },
             {
-              text:'Animation Duration',
-              link:'/utilities/animation-duration'
+              text: 'Animation Duration',
+              link: '/utilities/animation-duration',
             },
             {
-              text:'Animation Delay',
-              link:'/utilities/animation-delay'
+              text: 'Animation Delay',
+              link: '/utilities/animation-delay',
             },
             {
-              text:'Animation Iteration Count',
-              link:'/utilities/animation-iteration-count'
-            }
-            ,
+              text: 'Animation Iteration Count',
+              link: '/utilities/animation-iteration-count',
+            },
             {
-              text:'Preset Attributify',
-              link:'/utilities/preset-attributify'
-            }
-          ]
+              text: 'Preset Attributify',
+              link: '/utilities/preset-attributify',
+            },
+          ],
         },
         {
-          text:'Demo',
-          items:[
+          text: 'Demo',
+          items: [
             {
-              text:'Live',
-              link:'/demo/'
-            }
-          ]
-        }
-      ]
-    }
+              text: 'Live',
+              link: '/demo/',
+            },
+          ],
+        },
+      ],
+    },
   },
 })

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,6 +3,7 @@ import Theme from 'vitepress/theme'
 import '../style/vars.css'
 import '../style/main.css'
 import 'uno.css'
+
 // import HomePage from '../components/HomePage.vue'
 
 export default {

--- a/docs/.vitepress/utils/animations.ts
+++ b/docs/.vitepress/utils/animations.ts
@@ -1,158 +1,158 @@
 class Item {
-  label:string
-  value:string
+  label: string
+  value: string
 
-  constructor(label: string,value: string) {
-    this.label = label;
-    this.value = value;
+  constructor(label: string, value: string) {
+    this.label = label
+    this.value = value
   }
 }
 
 const Animations: Record<string, Array<Item>> = {
 
   'Attention Seekers': [
-    {label:'bounce',value:'bounce'},
-    {label:'flash',value:'flash'},
-    {label:'pulse',value:'pulse'},
-    {label:'rubberBand',value:'rubber-band'},
-    {label:'shakeX',value:'shake-x'},
-    {label:'shakeY',value:'shake-y'},
-    {label:'headShake',value:'head-shake'},
-    {label:'swing',value:'swing'},
-    {label:'tada',value:'tada'},
-    {label:'wobble',value:'wobble'},
-    {label:'jello',value:'jello'},
-    {label:'heartBeat',value:'heart-beat'},
+    { label: 'bounce', value: 'bounce' },
+    { label: 'flash', value: 'flash' },
+    { label: 'pulse', value: 'pulse' },
+    { label: 'rubberBand', value: 'rubber-band' },
+    { label: 'shakeX', value: 'shake-x' },
+    { label: 'shakeY', value: 'shake-y' },
+    { label: 'headShake', value: 'head-shake' },
+    { label: 'swing', value: 'swing' },
+    { label: 'tada', value: 'tada' },
+    { label: 'wobble', value: 'wobble' },
+    { label: 'jello', value: 'jello' },
+    { label: 'heartBeat', value: 'heart-beat' },
   ],
 
   'Back Entrances': [
-    {label:'backInDown',value:'back-in-down'},
-    {label:'backInLeft',value:'back-in-left'},
-    {label:'backInRight',value:'back-in-right'},
-    {label:'backInUp',value:'back-in-up'}
+    { label: 'backInDown', value: 'back-in-down' },
+    { label: 'backInLeft', value: 'back-in-left' },
+    { label: 'backInRight', value: 'back-in-right' },
+    { label: 'backInUp', value: 'back-in-up' },
   ],
 
   'Back Exits': [
-    {label:'backOutDown',value:'back-out-down'},
-    {label:'backOutLeft',value:'back-out-left'},
-    {label:'backOutRight',value:'back-out-right'},
-    {label:'backOutUp',value:'back-out-up'}
+    { label: 'backOutDown', value: 'back-out-down' },
+    { label: 'backOutLeft', value: 'back-out-left' },
+    { label: 'backOutRight', value: 'back-out-right' },
+    { label: 'backOutUp', value: 'back-out-up' },
   ],
 
   'Bouncing Entrances': [
-    {label:'bounceIn',value:'bounce-in'},
-    {label:'bounceInDown',value:'bounce-in-down'},
-    {label:'bounceInLeft',value:'bounce-in-left'},
-    {label:'bounceInRight',value:'bounce-in-right'},
-    {label:'bounceInUp',value:'bounce-in-up'}
+    { label: 'bounceIn', value: 'bounce-in' },
+    { label: 'bounceInDown', value: 'bounce-in-down' },
+    { label: 'bounceInLeft', value: 'bounce-in-left' },
+    { label: 'bounceInRight', value: 'bounce-in-right' },
+    { label: 'bounceInUp', value: 'bounce-in-up' },
   ],
 
   'Bouncing Exits': [
-    {label:'bounceOut',value:'bounce-out'},
-    {label:'bounceOutDown',value:'bounce-out-down'},
-    {label:'bounceOutLeft',value:'bounce-out-left'},
-    {label:'bounceOutRight',value:'bounce-out-right'},
-    {label:'bounceOutUp',value:'bounce-out-up'},
+    { label: 'bounceOut', value: 'bounce-out' },
+    { label: 'bounceOutDown', value: 'bounce-out-down' },
+    { label: 'bounceOutLeft', value: 'bounce-out-left' },
+    { label: 'bounceOutRight', value: 'bounce-out-right' },
+    { label: 'bounceOutUp', value: 'bounce-out-up' },
   ],
 
   'Fade Entrances': [
-    {label:'fadeIn',value:'fade-in'},
-    {label:'fadeInDown',value:'fade-in-down'},
-    {label:'fadeInDownBig',value:'fade-in-down-big'},
-    {label:'fadeInLeft',value:'fade-in-left'},
-    {label:'fadeInLeftBig',value:'fade-in-left-big'},
-    {label:'fadeInRight',value:'fade-in-right'},
-    {label:'fadeInRightBig',value:'fade-in-right-big'},
-    {label:'fadeInUp',value:'fade-in-up'},
-    {label:'fadeInUpBig',value:'fade-in-up-big'},
-    {label:'fadeInTopLeft',value:'fade-in-top-left'},
-    {label:'fadeInTopRight',value:'fade-in-top-right'},
-    {label:'fadeInBottomLeft',value:'fade-in-bottom-left'},
-    {label:'fadeInBottomRight',value:'fade-in-bottom-right'},
+    { label: 'fadeIn', value: 'fade-in' },
+    { label: 'fadeInDown', value: 'fade-in-down' },
+    { label: 'fadeInDownBig', value: 'fade-in-down-big' },
+    { label: 'fadeInLeft', value: 'fade-in-left' },
+    { label: 'fadeInLeftBig', value: 'fade-in-left-big' },
+    { label: 'fadeInRight', value: 'fade-in-right' },
+    { label: 'fadeInRightBig', value: 'fade-in-right-big' },
+    { label: 'fadeInUp', value: 'fade-in-up' },
+    { label: 'fadeInUpBig', value: 'fade-in-up-big' },
+    { label: 'fadeInTopLeft', value: 'fade-in-top-left' },
+    { label: 'fadeInTopRight', value: 'fade-in-top-right' },
+    { label: 'fadeInBottomLeft', value: 'fade-in-bottom-left' },
+    { label: 'fadeInBottomRight', value: 'fade-in-bottom-right' },
   ],
 
   'Fade Exits': [
-    {label:'fadeOut',value:'fade-out'},
-    {label:'fadeOutDown',value:'fade-out-down'},
-    {label:'fadeOutDownBig',value:'fade-out-down-big'},
-    {label:'fadeOutLeft',value:'fade-out-left'},
-    {label:'fadeOutLeftBig',value:'fade-out-left-big'},
-    {label:'fadeOutRight',value:'fade-out-right'},
-    {label:'fadeOutRightBig',value:'fade-out-right-big'},
-    {label:'fadeOutUp',value:'fade-out-up'},
-    {label:'fadeOutUpBig',value:'fade-out-up-big'},
-    {label:'fadeOutTopLeft',value:'fade-out-top-left'},
-    {label:'fadeOutTopRight',value:'fade-out-top-right'},
-    {label:'fadeOutBottomRight',value:'fade-out-bottom-right'},
-    {label:'fadeOutBottomLeft',value:'fade-out-bottom-left'},
+    { label: 'fadeOut', value: 'fade-out' },
+    { label: 'fadeOutDown', value: 'fade-out-down' },
+    { label: 'fadeOutDownBig', value: 'fade-out-down-big' },
+    { label: 'fadeOutLeft', value: 'fade-out-left' },
+    { label: 'fadeOutLeftBig', value: 'fade-out-left-big' },
+    { label: 'fadeOutRight', value: 'fade-out-right' },
+    { label: 'fadeOutRightBig', value: 'fade-out-right-big' },
+    { label: 'fadeOutUp', value: 'fade-out-up' },
+    { label: 'fadeOutUpBig', value: 'fade-out-up-big' },
+    { label: 'fadeOutTopLeft', value: 'fade-out-top-left' },
+    { label: 'fadeOutTopRight', value: 'fade-out-top-right' },
+    { label: 'fadeOutBottomRight', value: 'fade-out-bottom-right' },
+    { label: 'fadeOutBottomLeft', value: 'fade-out-bottom-left' },
   ],
 
   'Flippers': [
-    {label:'flip',value:'flip'},
-    {label:'flipInX',value:'flip-in-x'},
-    {label:'flipInY',value:'flip-in-y'},
-    {label:'flipOutX',value:'flip-out-x'},
-    {label:'flipOutY',value:'flip-out-y'}
+    { label: 'flip', value: 'flip' },
+    { label: 'flipInX', value: 'flip-in-x' },
+    { label: 'flipInY', value: 'flip-in-y' },
+    { label: 'flipOutX', value: 'flip-out-x' },
+    { label: 'flipOutY', value: 'flip-out-y' },
   ],
 
   'LightSpeed': [
-    {label:'lightSpeedInRight',value:'light-speed-in-right'},
-    {label:'lightSpeedInLeft',value:'light-speed-in-left'},
-    {label:'lightSpeedOutRight',value:'light-speed-out-right'},
-    {label:'lightSpeedOutLeft',value:'light-speed-out-left'}
+    { label: 'lightSpeedInRight', value: 'light-speed-in-right' },
+    { label: 'lightSpeedInLeft', value: 'light-speed-in-left' },
+    { label: 'lightSpeedOutRight', value: 'light-speed-out-right' },
+    { label: 'lightSpeedOutLeft', value: 'light-speed-out-left' },
   ],
 
   'Rotating Entrances': [
-    {label:'rotateIn',value:'rotate-in'},
-    {label:'rotateInDownLeft',value:'rotate-in-down-left'},
-    {label:'rotateInDownRight',value:'rotate-in-down-right'},
-    {label:'rotateInUpLeft',value:'rotate-in-up-left'},
-    {label:'rotateInUpRight',value:'rotate-in-up-right'},
+    { label: 'rotateIn', value: 'rotate-in' },
+    { label: 'rotateInDownLeft', value: 'rotate-in-down-left' },
+    { label: 'rotateInDownRight', value: 'rotate-in-down-right' },
+    { label: 'rotateInUpLeft', value: 'rotate-in-up-left' },
+    { label: 'rotateInUpRight', value: 'rotate-in-up-right' },
   ],
 
   'Rotating Exits': [
-    {label:'rotateOut',value:'rotate-out'},
-    {label:'rotateOutDownLeft',value:'rotate-out-down-left'},
-    {label:'rotateOutDownRight',value:'rotate-out-down-right'},
-    {label:'rotateOutUpLeft',value:'rotate-out-up-left'},
-    {label:'rotateOutUpRight',value:'rotate-out-up-right'},
+    { label: 'rotateOut', value: 'rotate-out' },
+    { label: 'rotateOutDownLeft', value: 'rotate-out-down-left' },
+    { label: 'rotateOutDownRight', value: 'rotate-out-down-right' },
+    { label: 'rotateOutUpLeft', value: 'rotate-out-up-left' },
+    { label: 'rotateOutUpRight', value: 'rotate-out-up-right' },
   ],
 
   'Specials': [
-    {label:'hinge',value:'hinge'},
-    {label:'jackInTheBox',value:'jack-in-the-box'},
-    {label:'rollIn',value:'roll-in'},
-    {label:'rollOut',value:'roll-out'}
+    { label: 'hinge', value: 'hinge' },
+    { label: 'jackInTheBox', value: 'jack-in-the-box' },
+    { label: 'rollIn', value: 'roll-in' },
+    { label: 'rollOut', value: 'roll-out' },
   ],
 
   'Zooming Entrances': [
-    {label:'zoomIn',value:'zoom-in'},
-    {label:'zoomInDown',value:'zoom-in-down'},
-    {label:'zoomInLeft',value:'zoom-in-left'},
-    {label:'zoomInRight',value:'zoom-in-right'},
-    {label:'zoomInUp',value:'zoom-in-up'}
+    { label: 'zoomIn', value: 'zoom-in' },
+    { label: 'zoomInDown', value: 'zoom-in-down' },
+    { label: 'zoomInLeft', value: 'zoom-in-left' },
+    { label: 'zoomInRight', value: 'zoom-in-right' },
+    { label: 'zoomInUp', value: 'zoom-in-up' },
   ],
 
   'Zooming Exits': [
-    {label:'zoomOut',value:'zoom-out'},
-    {label:'zoomOutDown',value:'zoom-out-down'},
-    {label:'zoomOutLeft',value:'zoom-out-left'},
-    {label:'zoomOutRight',value:'zoom-out-right'},
-    {label:'zoomOutUp',value:'zoom-out-up'}
+    { label: 'zoomOut', value: 'zoom-out' },
+    { label: 'zoomOutDown', value: 'zoom-out-down' },
+    { label: 'zoomOutLeft', value: 'zoom-out-left' },
+    { label: 'zoomOutRight', value: 'zoom-out-right' },
+    { label: 'zoomOutUp', value: 'zoom-out-up' },
   ],
 
   'Sliding Entrances': [
-    {label:'slideInDown',value:'slide-in-down'},
-    {label:'slideInLeft',value:'slide-in-left'},
-    {label:'slideInRight',value:'slide-in-right'},
-    {label:'slideInUp',value:'slide-in-up'}
+    { label: 'slideInDown', value: 'slide-in-down' },
+    { label: 'slideInLeft', value: 'slide-in-left' },
+    { label: 'slideInRight', value: 'slide-in-right' },
+    { label: 'slideInUp', value: 'slide-in-up' },
   ],
 
   'Sliding Exits': [
-    {label:'slideOutDown',value:'slide-out-down'},
-    {label:'slideOutLeft',value:'slide-out-left'},
-    {label:'slideOutRight',value:'slide-out-right'},
-    {label:'slideOutUp',value:'slide-out-up'}
+    { label: 'slideOutDown', value: 'slide-out-down' },
+    { label: 'slideOutLeft', value: 'slide-out-left' },
+    { label: 'slideOutRight', value: 'slide-out-right' },
+    { label: 'slideOutUp', value: 'slide-out-up' },
   ],
 }
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.4",
   "private": "true",
   "description": "A configuration to use Animate.css with UnoCSS.",
-  "license": "MIT",
   "author": "Elone Hoo <huchengyea@163.com>",
+  "license": "MIT",
   "scripts": {
     "dev": "vitepress --port 3344 --open --host",
     "build": "pnpm -C ../ run core && vitepress build",

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -26,6 +26,6 @@ export default defineConfig({
           scale: 1.2,
         }),
       ],
-    })as unknown as Plugin,
+    }) as unknown as Plugin,
   ],
 })

--- a/example/vue3/src/App.vue
+++ b/example/vue3/src/App.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import animations from './utils/animations'
+
 const animation = ref(Object.values(animations)[0][0].value)
 const repeat = ref(false)
 const shouldAnimate = ref(false)
 const copied = ref(false)
-const handleRepeat: EventListener = (e) => {
+const handleRepeat: EventListener = () => {
   repeat.value = !repeat.value
 }
 const handleChange: EventListener = (e) => {
@@ -82,8 +83,8 @@ const copy: EventListener = () => {
         class="appearance-none border-x border-[#333] bg-[#f0f0f0] py-1 px-4"
         @change="handleChange"
       >
-        <optgroup v-for="(keyframes, type) in animations" :label="type">
-          <option v-for="keyframe in keyframes" :value="keyframe.value">
+        <optgroup v-for="(keyframes, type) in animations" :key="type" :label="type">
+          <option v-for="keyframe in keyframes" :key="keyframe.value" :value="keyframe.value">
             {{ keyframe.label }}
           </option>
         </optgroup>

--- a/example/vue3/src/components/Animated.vue
+++ b/example/vue3/src/components/Animated.vue
@@ -3,7 +3,8 @@
 </script>
 
 <template>
-  <div class="
+  <div
+    class="
     animated
     animated-bounce
     animated-flash

--- a/example/vue3/src/utils/animations.ts
+++ b/example/vue3/src/utils/animations.ts
@@ -1,158 +1,158 @@
 class Item {
-  label:string
-  value:string
+  label: string
+  value: string
 
-  constructor(label: string,value: string) {
-    this.label = label;
-    this.value = value;
+  constructor(label: string, value: string) {
+    this.label = label
+    this.value = value
   }
 }
 
 const Animations: Record<string, Array<Item>> = {
 
   'Attention Seekers': [
-    {label:'bounce',value:'bounce'},
-    {label:'flash',value:'flash'},
-    {label:'pulse',value:'pulse'},
-    {label:'rubberBand',value:'rubber-band'},
-    {label:'shakeX',value:'shake-x'},
-    {label:'shakeY',value:'shake-y'},
-    {label:'headShake',value:'head-shake'},
-    {label:'swing',value:'swing'},
-    {label:'tada',value:'tada'},
-    {label:'wobble',value:'wobble'},
-    {label:'jello',value:'jello'},
-    {label:'heartBeat',value:'heart-beat'},
+    { label: 'bounce', value: 'bounce' },
+    { label: 'flash', value: 'flash' },
+    { label: 'pulse', value: 'pulse' },
+    { label: 'rubberBand', value: 'rubber-band' },
+    { label: 'shakeX', value: 'shake-x' },
+    { label: 'shakeY', value: 'shake-y' },
+    { label: 'headShake', value: 'head-shake' },
+    { label: 'swing', value: 'swing' },
+    { label: 'tada', value: 'tada' },
+    { label: 'wobble', value: 'wobble' },
+    { label: 'jello', value: 'jello' },
+    { label: 'heartBeat', value: 'heart-beat' },
   ],
 
   'Back Entrances': [
-    {label:'backInDown',value:'back-in-down'},
-    {label:'backInLeft',value:'back-in-left'},
-    {label:'backInRight',value:'back-in-right'},
-    {label:'backInUp',value:'back-in-up'}
+    { label: 'backInDown', value: 'back-in-down' },
+    { label: 'backInLeft', value: 'back-in-left' },
+    { label: 'backInRight', value: 'back-in-right' },
+    { label: 'backInUp', value: 'back-in-up' },
   ],
 
   'Back Exits': [
-    {label:'backOutDown',value:'back-out-down'},
-    {label:'backOutLeft',value:'back-out-left'},
-    {label:'backOutRight',value:'back-out-right'},
-    {label:'backOutUp',value:'back-out-up'}
+    { label: 'backOutDown', value: 'back-out-down' },
+    { label: 'backOutLeft', value: 'back-out-left' },
+    { label: 'backOutRight', value: 'back-out-right' },
+    { label: 'backOutUp', value: 'back-out-up' },
   ],
 
   'Bouncing Entrances': [
-    {label:'bounceIn',value:'bounce-in'},
-    {label:'bounceInDown',value:'bounce-in-down'},
-    {label:'bounceInLeft',value:'bounce-in-left'},
-    {label:'bounceInRight',value:'bounce-in-right'},
-    {label:'bounceInUp',value:'bounce-in-up'}
+    { label: 'bounceIn', value: 'bounce-in' },
+    { label: 'bounceInDown', value: 'bounce-in-down' },
+    { label: 'bounceInLeft', value: 'bounce-in-left' },
+    { label: 'bounceInRight', value: 'bounce-in-right' },
+    { label: 'bounceInUp', value: 'bounce-in-up' },
   ],
 
   'Bouncing Exits': [
-    {label:'bounceOut',value:'bounce-out'},
-    {label:'bounceOutDown',value:'bounce-out-down'},
-    {label:'bounceOutLeft',value:'bounce-out-left'},
-    {label:'bounceOutRight',value:'bounce-out-right'},
-    {label:'bounceOutUp',value:'bounce-out-up'},
+    { label: 'bounceOut', value: 'bounce-out' },
+    { label: 'bounceOutDown', value: 'bounce-out-down' },
+    { label: 'bounceOutLeft', value: 'bounce-out-left' },
+    { label: 'bounceOutRight', value: 'bounce-out-right' },
+    { label: 'bounceOutUp', value: 'bounce-out-up' },
   ],
 
   'Fade Entrances': [
-    {label:'fadeIn',value:'fade-in'},
-    {label:'fadeInDown',value:'fade-in-down'},
-    {label:'fadeInDownBig',value:'fade-in-down-big'},
-    {label:'fadeInLeft',value:'fade-in-left'},
-    {label:'fadeInLeftBig',value:'fade-in-left-big'},
-    {label:'fadeInRight',value:'fade-in-right'},
-    {label:'fadeInRightBig',value:'fade-in-right-big'},
-    {label:'fadeInUp',value:'fade-in-up'},
-    {label:'fadeInUpBig',value:'fade-in-up-big'},
-    {label:'fadeInTopLeft',value:'fade-in-top-left'},
-    {label:'fadeInTopRight',value:'fade-in-top-right'},
-    {label:'fadeInBottomLeft',value:'fade-in-bottom-left'},
-    {label:'fadeInBottomRight',value:'fade-in-bottom-right'},
+    { label: 'fadeIn', value: 'fade-in' },
+    { label: 'fadeInDown', value: 'fade-in-down' },
+    { label: 'fadeInDownBig', value: 'fade-in-down-big' },
+    { label: 'fadeInLeft', value: 'fade-in-left' },
+    { label: 'fadeInLeftBig', value: 'fade-in-left-big' },
+    { label: 'fadeInRight', value: 'fade-in-right' },
+    { label: 'fadeInRightBig', value: 'fade-in-right-big' },
+    { label: 'fadeInUp', value: 'fade-in-up' },
+    { label: 'fadeInUpBig', value: 'fade-in-up-big' },
+    { label: 'fadeInTopLeft', value: 'fade-in-top-left' },
+    { label: 'fadeInTopRight', value: 'fade-in-top-right' },
+    { label: 'fadeInBottomLeft', value: 'fade-in-bottom-left' },
+    { label: 'fadeInBottomRight', value: 'fade-in-bottom-right' },
   ],
 
   'Fade Exits': [
-    {label:'fadeOut',value:'fade-out'},
-    {label:'fadeOutDown',value:'fade-out-down'},
-    {label:'fadeOutDownBig',value:'fade-out-down-big'},
-    {label:'fadeOutLeft',value:'fade-out-left'},
-    {label:'fadeOutLeftBig',value:'fade-out-left-big'},
-    {label:'fadeOutRight',value:'fade-out-right'},
-    {label:'fadeOutRightBig',value:'fade-out-right-big'},
-    {label:'fadeOutUp',value:'fade-out-up'},
-    {label:'fadeOutUpBig',value:'fade-out-up-big'},
-    {label:'fadeOutTopLeft',value:'fade-out-top-left'},
-    {label:'fadeOutTopRight',value:'fade-out-top-right'},
-    {label:'fadeOutBottomRight',value:'fade-out-bottom-right'},
-    {label:'fadeOutBottomLeft',value:'fade-out-bottom-left'},
+    { label: 'fadeOut', value: 'fade-out' },
+    { label: 'fadeOutDown', value: 'fade-out-down' },
+    { label: 'fadeOutDownBig', value: 'fade-out-down-big' },
+    { label: 'fadeOutLeft', value: 'fade-out-left' },
+    { label: 'fadeOutLeftBig', value: 'fade-out-left-big' },
+    { label: 'fadeOutRight', value: 'fade-out-right' },
+    { label: 'fadeOutRightBig', value: 'fade-out-right-big' },
+    { label: 'fadeOutUp', value: 'fade-out-up' },
+    { label: 'fadeOutUpBig', value: 'fade-out-up-big' },
+    { label: 'fadeOutTopLeft', value: 'fade-out-top-left' },
+    { label: 'fadeOutTopRight', value: 'fade-out-top-right' },
+    { label: 'fadeOutBottomRight', value: 'fade-out-bottom-right' },
+    { label: 'fadeOutBottomLeft', value: 'fade-out-bottom-left' },
   ],
 
   'Flippers': [
-    {label:'flip',value:'flip'},
-    {label:'flipInX',value:'flip-in-x'},
-    {label:'flipInY',value:'flip-in-y'},
-    {label:'flipOutX',value:'flip-out-x'},
-    {label:'flipOutY',value:'flip-out-y'}
+    { label: 'flip', value: 'flip' },
+    { label: 'flipInX', value: 'flip-in-x' },
+    { label: 'flipInY', value: 'flip-in-y' },
+    { label: 'flipOutX', value: 'flip-out-x' },
+    { label: 'flipOutY', value: 'flip-out-y' },
   ],
 
   'LightSpeed': [
-    {label:'lightSpeedInRight',value:'light-speed-in-right'},
-    {label:'lightSpeedInLeft',value:'light-speed-in-left'},
-    {label:'lightSpeedOutRight',value:'light-speed-out-right'},
-    {label:'lightSpeedOutLeft',value:'light-speed-out-left'}
+    { label: 'lightSpeedInRight', value: 'light-speed-in-right' },
+    { label: 'lightSpeedInLeft', value: 'light-speed-in-left' },
+    { label: 'lightSpeedOutRight', value: 'light-speed-out-right' },
+    { label: 'lightSpeedOutLeft', value: 'light-speed-out-left' },
   ],
 
   'Rotating Entrances': [
-    {label:'rotateIn',value:'rotate-in'},
-    {label:'rotateInDownLeft',value:'rotate-in-down-left'},
-    {label:'rotateInDownRight',value:'rotate-in-down-right'},
-    {label:'rotateInUpLeft',value:'rotate-in-up-left'},
-    {label:'rotateInUpRight',value:'rotate-in-up-right'},
+    { label: 'rotateIn', value: 'rotate-in' },
+    { label: 'rotateInDownLeft', value: 'rotate-in-down-left' },
+    { label: 'rotateInDownRight', value: 'rotate-in-down-right' },
+    { label: 'rotateInUpLeft', value: 'rotate-in-up-left' },
+    { label: 'rotateInUpRight', value: 'rotate-in-up-right' },
   ],
 
   'Rotating Exits': [
-    {label:'rotateOut',value:'rotate-out'},
-    {label:'rotateOutDownLeft',value:'rotate-out-down-left'},
-    {label:'rotateOutDownRight',value:'rotate-out-down-right'},
-    {label:'rotateOutUpLeft',value:'rotate-out-up-left'},
-    {label:'rotateOutUpRight',value:'rotate-out-up-right'},
+    { label: 'rotateOut', value: 'rotate-out' },
+    { label: 'rotateOutDownLeft', value: 'rotate-out-down-left' },
+    { label: 'rotateOutDownRight', value: 'rotate-out-down-right' },
+    { label: 'rotateOutUpLeft', value: 'rotate-out-up-left' },
+    { label: 'rotateOutUpRight', value: 'rotate-out-up-right' },
   ],
 
   'Specials': [
-    {label:'hinge',value:'hinge'},
-    {label:'jackInTheBox',value:'jack-in-the-box'},
-    {label:'rollIn',value:'roll-in'},
-    {label:'rollOut',value:'roll-out'}
+    { label: 'hinge', value: 'hinge' },
+    { label: 'jackInTheBox', value: 'jack-in-the-box' },
+    { label: 'rollIn', value: 'roll-in' },
+    { label: 'rollOut', value: 'roll-out' },
   ],
 
   'Zooming Entrances': [
-    {label:'zoomIn',value:'zoom-in'},
-    {label:'zoomInDown',value:'zoom-in-down'},
-    {label:'zoomInLeft',value:'zoom-in-left'},
-    {label:'zoomInRight',value:'zoom-in-right'},
-    {label:'zoomInUp',value:'zoom-in-up'}
+    { label: 'zoomIn', value: 'zoom-in' },
+    { label: 'zoomInDown', value: 'zoom-in-down' },
+    { label: 'zoomInLeft', value: 'zoom-in-left' },
+    { label: 'zoomInRight', value: 'zoom-in-right' },
+    { label: 'zoomInUp', value: 'zoom-in-up' },
   ],
 
   'Zooming Exits': [
-    {label:'zoomOut',value:'zoom-out'},
-    {label:'zoomOutDown',value:'zoom-out-down'},
-    {label:'zoomOutLeft',value:'zoom-out-left'},
-    {label:'zoomOutRight',value:'zoom-out-right'},
-    {label:'zoomOutUp',value:'zoom-out-up'}
+    { label: 'zoomOut', value: 'zoom-out' },
+    { label: 'zoomOutDown', value: 'zoom-out-down' },
+    { label: 'zoomOutLeft', value: 'zoom-out-left' },
+    { label: 'zoomOutRight', value: 'zoom-out-right' },
+    { label: 'zoomOutUp', value: 'zoom-out-up' },
   ],
 
   'Sliding Entrances': [
-    {label:'slideInDown',value:'slide-in-down'},
-    {label:'slideInLeft',value:'slide-in-left'},
-    {label:'slideInRight',value:'slide-in-right'},
-    {label:'slideInUp',value:'slide-in-up'}
+    { label: 'slideInDown', value: 'slide-in-down' },
+    { label: 'slideInLeft', value: 'slide-in-left' },
+    { label: 'slideInRight', value: 'slide-in-right' },
+    { label: 'slideInUp', value: 'slide-in-up' },
   ],
 
   'Sliding Exits': [
-    {label:'slideOutDown',value:'slide-out-down'},
-    {label:'slideOutLeft',value:'slide-out-left'},
-    {label:'slideOutRight',value:'slide-out-right'},
-    {label:'slideOutUp',value:'slide-out-up'}
+    { label: 'slideOutDown', value: 'slide-out-down' },
+    { label: 'slideOutLeft', value: 'slide-out-left' },
+    { label: 'slideOutRight', value: 'slide-out-right' },
+    { label: 'slideOutUp', value: 'slide-out-up' },
   ],
 }
 

--- a/example/vue3/unocss.config.ts
+++ b/example/vue3/unocss.config.ts
@@ -18,5 +18,5 @@ export default defineConfig({
         mono: 'DM Mono',
       },
     }),
-  ]
+  ],
 })

--- a/package.json
+++ b/package.json
@@ -2,12 +2,8 @@
   "name": "animated-unocss",
   "version": "0.0.5",
   "description": "A configuration to use Animate.css with UnoCSS.",
-  "license": "MIT",
   "author": "Elone Hoo <hi@elonehoo.me>",
-  "keywords": [
-    "unocss",
-    "animated.css"
-  ],
+  "license": "MIT",
   "homepage": "https://github.com/elonehoo/animated-unocss#readme",
   "repository": {
     "type": "git",
@@ -16,9 +12,10 @@
   "bugs": {
     "url": "https://github.com/elonehoo/animated-unocss/issues"
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "keywords": [
+    "unocss",
+    "animated.css"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -27,6 +24,9 @@
     },
     "./*": "./*"
   },
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "*.d.ts"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
   - 'example/*'
-  - 'docs'
+  - docs

--- a/src/animated.ts
+++ b/src/animated.ts
@@ -1,7 +1,7 @@
-import { type CSSObject, type Rule } from 'unocss';
-import { type Theme } from '@unocss/preset-mini';
-import { handler } from '@unocss/preset-mini/utils';
-import animatedJSON from './animated.json';
+import { type CSSObject, type Rule } from 'unocss'
+import { type Theme } from '@unocss/preset-mini'
+import { handler } from '@unocss/preset-mini/utils'
+import animatedJSON from './animated.json'
 
 function getAnimated() {
   return animatedJSON as unknown as {
@@ -10,7 +10,7 @@ function getAnimated() {
       css: CSSObject
       keyframes: string
     }
-  };
+  }
 }
 
 export const durationShortcuts = {
@@ -18,7 +18,7 @@ export const durationShortcuts = {
   fast: 0.8,
   slow: 2,
   slower: 3,
-};
+}
 
 /**
  * animate.css
@@ -32,12 +32,12 @@ export const animatedRules: Rule<Theme>[] = [
   [
     new RegExp(`^animated-(${Object.keys(animatedJSON).join('|')})$`),
     ([, name]) => {
-      const { animationName, css, keyframes } = getAnimated()[name];
+      const { animationName, css, keyframes } = getAnimated()[name]
 
       return [
         `@keyframes ${animationName} { ${keyframes} }`,
         css,
-      ];
+      ]
     },
     {
       autocomplete: [
@@ -48,11 +48,11 @@ export const animatedRules: Rule<Theme>[] = [
   [
     /^animated-(infinite|(repeat-(infinite|(\d+(\.\d+)?))))$/,
     ([,,, repeat]) => {
-      const isInfinite = !repeat || repeat === 'infinite';
+      const isInfinite = !repeat || repeat === 'infinite'
 
       return {
         'animation-iteration-count': isInfinite ? 'infinite' : repeat,
-      };
+      }
     },
     {
       autocomplete: [
@@ -80,12 +80,12 @@ export const animatedRules: Rule<Theme>[] = [
       if (shortcut) {
         return {
           'animation-duration': `calc(var(--une-animated-duration) * ${durationShortcuts[shortcut as keyof typeof durationShortcuts]});`,
-        };
+        }
       }
 
       return {
         'animation-duration': v === 'none' ? '0ms' : handler.bracket.cssvar.time(v),
-      };
+      }
     },
     {
       autocomplete: [
@@ -95,4 +95,4 @@ export const animatedRules: Rule<Theme>[] = [
       ],
     },
   ],
-];
+]

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,25 @@ import { type Preset } from 'unocss'
 import { animatedRules } from './animated'
 import animatedName from './animatedName.json'
 
-export function animatedUno(): Preset<any> {
+interface Options {
+  /**
+   * Whether to output the entire animate.css.
+   * Which is very effective if you need to dynamically combine class names at runtime.
+   * @default true
+   */
+  buildFullVersion: boolean
+}
+
+export function animatedUno({
+  buildFullVersion = true,
+} = ({} as Options)): Preset<any> {
   return {
     name: 'animated-unocss',
     rules: [
       ...animatedRules,
     ],
-    safelist:animatedName.map(name=>'animated-'+name),
+    safelist: buildFullVersion
+      ? animatedName.map(name => `animated-${name}`)
+      : [],
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -81,8 +81,8 @@ describe('animated', () => {
       animated-infinite
       animated-repeat-infinite
       ${/* 0 ~ 66 */ Array.from({ length: 67 }, (_, i) => `animated-repeat-${i}`).join(' ')}
-      ${/* 0.1, 1.2, ...*/ Array.from({ length: 67 }, (_, i) => `animated-repeat-${i}.${removeLastZero(i + 1)}`).join(' ')}
-      ${/* 0_1, 1_2, ...*/ Array.from({ length: 7 }, (_, i) => `animated-repeat-${i}_${removeLastZero(i + 1)}`).join(' ')}
+      ${/* 0.1, 1.2, ... */ Array.from({ length: 67 }, (_, i) => `animated-repeat-${i}.${removeLastZero(i + 1)}`).join(' ')}
+      ${/* 0_1, 1_2, ... */ Array.from({ length: 7 }, (_, i) => `animated-repeat-${i}_${removeLastZero(i + 1)}`).join(' ')}
       ${/* a ~ z */ Array.from({ length: 26 }, (_, i) => `animated-repeat-${String.fromCharCode(97 + i)}`)}
     `)
 
@@ -115,8 +115,8 @@ describe('animated', () => {
       ${/* 0ms ~ 66ms */ Array.from({ length: 67 }, (_, i) => `animated-delay-${i}ms`).join(' ')}
       ${/* 0s ~ 66s */ Array.from({ length: 67 }, (_, i) => `animated-delay-${i}s`).join(' ')}
       ${/* 0.1, 1.2, ... */ Array.from({ length: 67 }, (_, i) => `animated-delay-${i}.${removeLastZero(i + 1)}`).join(' ')}
-      ${/* 0.1ms, 1.2ms, ...*/ Array.from({ length: 67 }, (_, i) => `animated-delay-${i}.${removeLastZero(i + 1)}ms`).join(' ')}
-      ${/* 0.1s, 1.2s, ...*/ Array.from({ length: 67 }, (_, i) => `animated-delay-${i}.${removeLastZero(i + 1)}s`).join(' ')}
+      ${/* 0.1ms, 1.2ms, ... */ Array.from({ length: 67 }, (_, i) => `animated-delay-${i}.${removeLastZero(i + 1)}ms`).join(' ')}
+      ${/* 0.1s, 1.2s, ... */ Array.from({ length: 67 }, (_, i) => `animated-delay-${i}.${removeLastZero(i + 1)}s`).join(' ')}
     `)
 
     expect(
@@ -158,9 +158,9 @@ describe('animated', () => {
       ${/* 0 ~ 66 */ Array.from({ length: 67 }, (_, i) => `animated-duration-${i}`).join(' ')}
       ${/* 0ms ~ 66ms */ Array.from({ length: 67 }, (_, i) => `animated-duration-${i}ms`).join(' ')}
       ${/* 0s ~ 66s */ Array.from({ length: 67 }, (_, i) => `animated-duration-${i}s`).join(' ')}
-      ${/* 0.1, 1.2, ...*/
+      ${/* 0.1, 1.2, ... */
       Array.from({ length: 67 }, (_, i) => `animated-duration-${i}.${removeLastZero(i + 1)}`).join(' ')}
-      ${/* 0.1ms, 1.2ms, ...*/ Array.from({ length: 67 }, (_, i) => `animated-duration-${i}.${removeLastZero(i + 1)}ms`).join(' ')}
+      ${/* 0.1ms, 1.2ms, ... */ Array.from({ length: 67 }, (_, i) => `animated-duration-${i}.${removeLastZero(i + 1)}ms`).join(' ')}
       ${/* 0.1s, 1.2s, ... */ Array.from({ length: 67 }, (_, i) => `animated-duration-${i}.${removeLastZero(i + 1)}s`).join(' ')}
     `)
 
@@ -199,5 +199,4 @@ describe('animated', () => {
       ),
     )
   })
-
 })

--- a/test/package.json
+++ b/test/package.json
@@ -4,11 +4,14 @@
   "version": "0.0.0",
   "private": true,
   "description": "A configuration to use Animate.css with UnoCSS.",
-  "license": "MIT",
   "author": "Elone Hoo <huchengyea@163.com>",
+  "license": "MIT",
   "scripts": {
     "test": "vitest",
     "coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "c8": "^7.13.0"
   },
   "devDependencies": {
     "@types/lodash-es": "^4.17.6",
@@ -20,8 +23,5 @@
     "postcss-js": "^4.0.1",
     "unocss": "^0.50.4",
     "vitest": "0.29.2"
-  },
-  "dependencies": {
-    "c8": "^7.13.0"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import path from 'path'
+import path from 'node:path'
 import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
After #34 , the final behavior of the plug-in changed, and now it always outputs the full version of animate.css styling code, regardless of whether some animation classes are actually used in the code, so the main job of this PR is to solve this problem by adding an option to the plugin, used to manually specify whether to build the full version, the default is true